### PR TITLE
Fix install. Update .gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 config.json
 __pycache__
 __pycache__/*
+docker-compose.override.yml
+.env

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To get started with SkillAegis, follow these steps:
    ```bash
    # Editor
    pushd SkillAegis-Editor
+   git checkout develop
    python3 -m venv venv
    source venv/bin/activate
    pip install -U setuptools pip
@@ -65,7 +66,7 @@ To get started with SkillAegis, follow these steps:
    source venv/bin/activate
    pip install -U setuptools pip
    pip install -r backend/requirements.txt
-   cp config.py.sample config.py
+   cp backend/config.py.sample backend/config.py
    # [recommended] Update the configuration
    deactivate
    popd
@@ -103,7 +104,7 @@ To update the project, follow these steps:
    source venv/bin/activate
    pip install -U setuptools pip
    pip install -U -r requirements.txt
-   diff -u config.py.sample config.py
+   diff -u backend/config.py.sample backend/config.py
    deactivate
    popd
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,3 @@
-volumes:
-  skillaegis_main_storage:
-  skillaegis_dashboard_storage:
-  skillaegis_editor_storage:
-
 services:
     skillaegis-main:
         build:
@@ -16,7 +11,6 @@ services:
             - SKILLAEGIS_DASHBOARD_URL=http://localhost:4001
             - SKILLAEGIS_EDITOR_URL=http://localhost:4002
         volumes:
-            - skillaegis_main_storage:/app/
             - ./scenarios:/app/scenarios
         ports:
             - "4000:4000"
@@ -35,7 +29,6 @@ services:
             - SKILLAEGIS_MISP_APIKEY=${SKILLAEGIS_MISP_APIKEY:-FI4gCRghRZvLVjlLPLTFZ852x2njkkgPSz0zQ3E0}
             - SKILLAEGIS_MISP_SKIPSSL=${SKILLAEGIS_MISP_SKIPSSL:-1}
         volumes:
-            - skillaegis_dashboard_storage:/app/
             - ./scenarios:/app/scenarios
         ports:
             - "4001:4001"
@@ -51,7 +44,6 @@ services:
             - SKILLAEGIS_PORT=4002
             - SKILLAEGIS_EXERCISE_FOLDER=scenarios
         volumes:
-            - skillaegis_editor_storage:/app/
             - ./scenarios:/app/scenarios
         ports:
             - "4002:4002"


### PR DESCRIPTION
Related to: https://github.com/SkillAegis/SkillAegis-Dashboard/pull/7

# What is this PR?
Readme lacked the correct path references to the SkillAegis-Dashboard backend directory.

Also added relevant files (.env & docker-compose.override.yml) to .gitignore to avoid any future commits containing them.

docker-compose.yml update removes references to the unused volume mounts. The volume mounts break the installation when using Docker. 

## Additional info
Regarding the broken docker and local installation, PR https://github.com/SkillAegis/SkillAegis-Dashboard/pull/5 might solve this issue. I haven't tested that PR yet but it's close enough to this PR.

develop branch was used for both repositories as main branch seemed to have other problems as well. This is reflected in the README.md instructions update by checking out to correct branch.